### PR TITLE
Generalize type of `runGetPacked`

### DIFF
--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -298,7 +298,7 @@ parseVarInt = Parser $
         VarintField i -> Right (fromIntegral i)
         wrong -> throwWireTypeError "varint" wrong
 
-runGetPacked :: Get [a] -> Parser RawPrimitive [a]
+runGetPacked :: Get a -> Parser RawPrimitive a
 runGetPacked g = Parser $
     \case
         LengthDelimitedField bs ->


### PR DESCRIPTION
The inferred type of `runGetPacked` does not require that the supplied `Get`
decoder returns a list (even though that's the only case we use).  This change
generalizes the type so that we could (in theory) later use more efficient
decoders for packed values that return, say, `Vector a`, instead of `[a]`