### PR TITLE
Tweak `oneof` interface

### DIFF
--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -459,7 +459,7 @@ at :: Parser RawField a -> FieldNumber -> Parser RawMessage a
 at parser fn = Parser $ runParser parser . fromMaybe mempty . M.lookup fn
 
 -- | Try to parse different field numbers with their respective parsers. This is
--- used to express alternative between possible fields of a oneof .
+-- used to express alternative between possible fields of a oneof.
 --
 -- TODO: contrary to the protobuf spec, in the case of multiple fields number
 -- matching the oneof content, the choice of field is biased to the order of the
@@ -471,11 +471,11 @@ oneof :: a
          -- ^ The value to produce when no field numbers belonging to the oneof
          -- are present in the input
       -> [(FieldNumber, Parser RawField a)]
-         -- ^ Left-biased subfield parsers, one per field number belonging to
+         -- ^ Left-biased oneof field parsers, one per field number belonging to
          -- the oneof
       -> Parser RawMessage a
 oneof def parsersByFieldNum = Parser $ \input ->
-  case msum $ (\(num,p) -> (p,) <$> M.lookup num input) <$> parsersByFieldNum of
+  case msum ((\(num,p) -> (p,) <$> M.lookup num input) <$> parsersByFieldNum) of
     Nothing     -> pure def
     Just (p, v) -> runParser p v
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -120,15 +120,26 @@ roundTripTests = testGroup "Roundtrip tests"
                                             <*> one Decode.uint32 0 `at`
                                                 fieldNumber 2)
                            , roundTrip "oneof"
-                                        (\case TString text -> Encode.text (fieldNumber 3) text
-                                               TInt64 i     -> Encode.int64 (fieldNumber 2) i)
-                                        (oneof [(fieldNumber 2, TInt64 <$> one Decode.int64 0)
-                                               ,(fieldNumber 3, TString <$> one Decode.text mempty)])
+                                        (\case Just (TString text) -> Encode.text (fieldNumber 3) text
+                                               Just (TInt64 i)     -> Encode.int64 (fieldNumber 2) i
+                                               Nothing             -> mempty
+                                        )
+                                        (oneof Nothing
+                                               [ (fieldNumber 2, Just . TInt64  <$> one Decode.int64 0)
+                                               , (fieldNumber 3, Just . TString <$> one Decode.text mempty)
+                                               ]
+                                        )
                            , roundTrip "oneof-last"
-                                        (\case TString text -> Encode.text (fieldNumber 3) "something" <> Encode.text (fieldNumber 3) text
-                                               TInt64 i     -> Encode.int64 (fieldNumber 2) 20000000 <> Encode.int64 (fieldNumber 2) i)
-                                        (oneof [(fieldNumber 2, TInt64 <$> one Decode.int64 0)
-                                               ,(fieldNumber 3, TString <$> one Decode.text mempty)])
+                                        (\case Just (TString text) -> Encode.text (fieldNumber 3) "something" <> Encode.text (fieldNumber 3) text
+                                               Just (TInt64 i)     -> Encode.int64 (fieldNumber 2) 20000000 <> Encode.int64 (fieldNumber 2) i
+                                               Nothing             -> mempty
+                                        )
+                                        (oneof Nothing
+                                               [ (fieldNumber 2, Just . TInt64  <$> one Decode.int64 0)
+                                               , (fieldNumber 3, Just . TString <$> one Decode.text mempty)
+                                               ]
+                                        )
+
                            ]
 
 roundTrip :: (Show a, Eq a, Arbitrary a)


### PR DESCRIPTION
This is a small change to `Proto3.Wire.Decode.oneof` to take an explicit default rather than using the result of the first parser in the given list as the default value. Simplifies `proto3-suite` codegen.

cc @vincenthz 