### PR TITLE
Add a Semigroup instance to satisfy the GHC 8.4.x superclass

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -40,10 +40,10 @@ test-suite tests
   build-depends:       base >=4.9 && <=5.0,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
-                       doctest >= 0.7.0 && <0.15,
+                       doctest >= 0.7.0 && <0.17,
                        proto3-wire,
                        QuickCheck >=2.8 && <3.0,
                        tasty >= 0.11 && <1.2,
-                       tasty-hunit >= 0.9 && <0.10,
+                       tasty-hunit >= 0.9 && <0.11,
                        tasty-quickcheck >= 0.8.4 && <0.11,
                        text >= 0.2 && <1.3

--- a/release.nix
+++ b/release.nix
@@ -4,19 +4,22 @@ let
   fetchNixpkgs = import ./nix/fetchNixpkgs.nix;
 
   nixpkgs = fetchNixpkgs {
-    rev          = "e942479be49c3d1b586201be7488d7190ff46255";
-    sha256       = "0q4jdlvx0i1bhxy7xk85mflv7fchlap28sis9qn4p3naz2l46mbw";
-    outputSha256 = "0n424nkkjzvvsk0bcvb4lhyjl4k88nc5dzayjvscsqxssh1g06yh";
+   rev          = "a8ff2616603a6ff6bfb060368c12a973c8e007f6";
+   sha256       = "15l57ra62w9imqv3cfx9qp1fag3mqp95x0hdh81cqjb663qxihlg";
+   outputSha256 = "1nkpbwdx1jgr2pv5arllk6k56h3xc61jal7qi66g21qsx6daf0g3";
   };
 
-  config = {
-    packageOverrides = pkgs: {
-      haskell = pkgs.haskell // {
-        packages = pkgs.haskell.packages // {
-          "${compiler}" = pkgs.haskell.packages."${compiler}".override {
+  config   = { allowUnfree = true; };
+
+  overlays = [
+    (newPkgs: oldPkgs: rec {
+
+      haskell = oldPkgs.haskell // {
+        packages = oldPkgs.haskell.packages // {
+          "${compiler}" = oldPkgs.haskell.packages."${compiler}".override {
             overrides =
               let
-                packageSourceOverrides = pkgs.haskell.lib.packageSourceOverrides {
+                packageSourceOverrides = oldPkgs.haskell.lib.packageSourceOverrides {
                   "proto3-wire" = ./.;
                 };
 
@@ -24,18 +27,17 @@ let
                 };
 
               in
-                pkgs.lib.composeExtensions
+                newPkgs.lib.composeExtensions
                   packageSourceOverrides
                   manualOverrides;
           };
         };
       };
-    };
-  };
+    })
+  ];
 
-  pkgs = import nixpkgs { inherit config; };
+  pkgs = import nixpkgs { inherit config overlays; };
 
 in
 
-{ proto3-wire = pkgs.haskell.packages."${compiler}".proto3-wire;
-}
+  { proto3-wire = pkgs.haskell.packages."${compiler}".proto3-wire; }

--- a/src/Proto3/Wire/Builder.hs
+++ b/src/Proto3/Wire/Builder.hs
@@ -100,10 +100,11 @@ import           System.IO                     ( Handle )
 data Builder = Builder {-# UNPACK #-} !(Sum Word) BB.Builder
 
 instance Semigroup Builder where
+  (<>) (Builder s b) (Builder s1 b1) = Builder (s <> s1) (b <> b1)
 
 instance Monoid Builder where
   mempty = Builder mempty mempty
-  mappend (Builder s b) (Builder s1 b1) = Builder (s <> s1) (b <> b1)
+  mappend = (<>)
 
 instance Show Builder where
   showsPrec prec builder =

--- a/src/Proto3/Wire/Builder.hs
+++ b/src/Proto3/Wire/Builder.hs
@@ -100,7 +100,7 @@ import           System.IO                     ( Handle )
 data Builder = Builder {-# UNPACK #-} !(Sum Word) BB.Builder
 
 instance Semigroup Builder where
-  (<>) (Builder s b) (Builder s1 b1) = Builder (s <> s1) (b <> b1)
+  Builder s b <> Builder s1 b1 = Builder (s <> s1) (b <> b1)
 
 instance Monoid Builder where
   mempty = Builder mempty mempty


### PR DESCRIPTION
This change updates `proto3-wire` to build against both GHC 8.0.x and GHC 8.4.x.