### PR TITLE
Fix test suite failures induced by Seq -> [] move.

### DIFF
--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -535,7 +535,7 @@ embeddedToParsedFields (LengthDelimitedField bs) =
         Left err -> Left (EmbeddedError ("Failed to parse embedded message: "
                                              <> (pack err))
                                         Nothing)
-        Right result -> return (fmap reverse $ toMap result)
+        Right result -> return (toMap result)
 embeddedToParsedFields wrong =
     throwWireTypeError "embedded" wrong
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -123,6 +123,22 @@ roundTripTests = testGroup "Roundtrip tests"
                                                                    0 `at`
                                                                    fieldNumber 1))
                                             `at` fieldNumber 1)
+                           , roundTrip "embeddedList"
+                                       (Encode.embedded (fieldNumber 1) .
+                                            Encode.packedFixed32 (fieldNumber 1))
+                                       (fmap (fromMaybe [0,1,2,3,4])
+                                             (Decode.embedded (one Decode.packedFixed32 []
+                                                                   `at`
+                                                                   fieldNumber 1))
+                                            `at` fieldNumber 1)
+                           , roundTrip "embeddedListUnpacked"
+                                       (Encode.embedded (fieldNumber 1) .
+                                            (foldMap . Encode.int32) (fieldNumber 1))
+                                       (fmap (fromMaybe [0,1,2,3,4])
+                                             (Decode.embedded (repeated Decode.int32
+                                                                   `at`
+                                                                   fieldNumber 1))
+                                            `at` fieldNumber 1)
                            , roundTrip "multiple fields"
                                        (\(a, b) -> Encode.int32 (fieldNumber 1)
                                                                 a <>


### PR DESCRIPTION
remove an extraneous reverse that led to failures. its ok to keep everything reversed here since it still gets consumed by things expecting it in this order.
