### PR TITLE
Relax version constraints for Stackage LTS 13.x

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -20,7 +20,7 @@ library
   build-depends:       base >=4.9 && <=5.0,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
-                       containers ==0.5.*,
+                       containers >=0.5 && < 0.7,
                        deepseq ==1.4.*,
                        hashable <1.3,
                        safe ==0.3.*,
@@ -43,7 +43,7 @@ test-suite tests
                        doctest >= 0.7.0 && <0.17,
                        proto3-wire,
                        QuickCheck >=2.8 && <3.0,
-                       tasty >= 0.11 && <1.2,
+                       tasty >= 0.11 && <1.3,
                        tasty-hunit >= 0.9 && <0.11,
                        tasty-quickcheck >= 0.8.4 && <0.11,
                        text >= 0.2 && <1.3


### PR DESCRIPTION
Seems that tests pass with LTS 13.6.