### PR TITLE
Add MINIMAL pragma to ChooseNat.

### DIFF
--- a/src/Proto3/Wire/Reverse/Width.hs
+++ b/src/Proto3/Wire/Reverse/Width.hs
@@ -99,3 +99,6 @@ class ChooseNat b
 
     commMaxNat ::
       forall v w . Proxy# '(v, w) -> b (Max v w) -> b (Max w v)
+
+    {-# MINIMAL boolNat, assocLMaxNat, assocRMaxNat, commMaxNat
+              | ifNat, assocLMaxNat, assocRMaxNat, commMaxNat  #-}


### PR DESCRIPTION
Without the pragma one could accidentally leave both 'ifNat'
and 'boolNat' undefined, leading to an infinite loop because
each has a default implementation in terms of the other.