### PR TITLE
Allows tasty 1.3 & 1.4

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -58,7 +58,7 @@ test-suite tests
                        doctest >= 0.7.0 && <0.18,
                        proto3-wire,
                        QuickCheck >=2.8 && <3.0,
-                       tasty >= 0.11 && <1.3,
+                       tasty >= 0.11 && <1.5,
                        tasty-hunit >= 0.9 && <0.11,
                        tasty-quickcheck >= 0.8.4 && <0.11,
                        text >= 0.2 && <1.3,


### PR DESCRIPTION
Related to commercialhaskell/stackage#5795; I haven't tested this locally, I just figured it would be easy to make the change and let CI yell at me if something broke.