### PR TITLE
Allow ghc-prim==0.7.0 to enable ghc-9.0.1.

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -28,7 +28,7 @@ library
                        cereal >= 0.5.1 && <0.6,
                        containers >=0.5 && < 0.7,
                        deepseq ==1.4.*,
-                       ghc-prim >=0.5.3 && <0.7,
+                       ghc-prim >=0.5.3 && <0.8,
                        hashable <1.4,
                        parameterized >=0.5.0.0 && <1,
                        primitive >=0.6.4 && <0.8,

--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -199,7 +199,7 @@ gwireType 2 = return LengthDelimited
 gwireType wt = Left $ "wireType got unknown wire type: " ++ show wt
 
 safeSplit :: Int -> B.ByteString -> Either String (B.ByteString, B.ByteString)
-safeSplit !i! b | B.length b < i = Left "failed to parse varint128: not enough bytes"
+safeSplit !i !b | B.length b < i = Left "failed to parse varint128: not enough bytes"
                 | otherwise = Right $ B.splitAt i b
 
 takeWT :: WireType -> B.ByteString -> Either String (ParsedField, B.ByteString)


### PR DESCRIPTION
Allow ghc-prim==0.7.x and fixes a bang pattern syntax (the original one is not parsed by ghc-9.0.1).