### PR TITLE
Export ZigZag codec

### DIFF
--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -72,6 +72,8 @@ module Proto3.Wire.Decode
     , repeated
     , embedded
     , embedded'
+      -- * ZigZag codec
+    , zigZagDecode
       -- * Exported For Doctest Only
     , toMap
     ) where


### PR DESCRIPTION
They are useful standalone functions, and in particular would let me
reduce some duplication in awakesecurity/proto3-suite#151