### PR TITLE
Updated pinned nixpkgs to 21.05

### DIFF
--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -1,0 +1,14 @@
+{ compiler }:
+
+pkgsNew: pkgsOld:
+
+{
+  haskellPackages = pkgsOld.haskell.packages."${compiler}".override (old: {
+    overrides =
+      pkgsOld.lib.composeExtensions
+        (old.overrides or (_: _: {}))
+        (haskellPackagesFinal: haskellPackagesPrev: {
+          proto3-wire = haskellPackagesPrev.callCabal2nix "proto3-wire" ../. { };
+        });
+  });
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,12 @@
+args:
+
+let
+  # nixpkgs release 21.05
+  rev = "7e9b0dff974c89e070da1ad85713ff3c20b0ca97";
+  sha256 = "1ckzhh24mgz6jd1xhfgx0i9mijk6xjqxwsshnvq789xsavrmsc36";
+
+  nixpkgs = builtins.fetchTarball {
+    url = "https://github.com/NixOS/nixpkgs/archive/${rev}.tar.gz";
+    inherit sha256;
+  };
+in import nixpkgs ({ config = { }; } // args)

--- a/nix/pkgs.nix
+++ b/nix/pkgs.nix
@@ -1,0 +1,7 @@
+import ./nixpkgs.nix {
+  overlays = [
+    (import ./haskell-packages.nix {
+      compiler = "ghc884";
+    })
+  ];
+}

--- a/release.nix
+++ b/release.nix
@@ -1,43 +1,6 @@
-{ compiler ? "ghc884" }:
-
 let
-  nixpkgs = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/9a1672105db0eebe8ef59f310397435f2d0298d0.tar.gz";
-    sha256 = "06z4r0aaha5qyd0prg7h1f5sjrsndca75150zf5w4ff6g9vdv1rb";
-  };
+  pkgs = import ./nix/pkgs.nix;
 
-  config = { allowBroken = true; };
-
-  overlay =
-    pkgsNew: pkgsOld: rec {
-
-      haskell = pkgsOld.haskell // {
-        packages = pkgsOld.haskell.packages // {
-          "${compiler}" = pkgsOld.haskell.packages.${compiler}.override (old: {
-            overrides =
-              let
-                packageSourceOverrides = pkgsNew.haskell.lib.packageSourceOverrides {
-                  "proto3-wire" = ./.;
-                };
-
-                manualOverrides = haskellPackagesNew: haskellPackagesOld: {
-                  parameterized =
-                    pkgsNew.haskell.lib.dontCheck
-                      haskellPackagesOld.parameterized;
-                };
-
-              in
-                pkgsNew.lib.foldr pkgsNew.lib.composeExtensions (old.overrides or (_: _: { }))
-                  [ packageSourceOverrides
-                    manualOverrides
-                  ];
-          });
-        };
-      };
-    };
-
-  pkgs = import nixpkgs { inherit config; overlays = [ overlay ]; };
-
-in
-  { proto3-wire = pkgs.haskell.packages."${compiler}".proto3-wire;
-  }
+in {
+  proto3-wire = pkgs.haskell.lib.buildStrictly pkgs.haskellPackages.proto3-wire;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,1 +1,10 @@
-(import ./release.nix {}).proto3-wire.env
+let
+  pkgs = import ./nix/pkgs.nix;
+
+  proto3-wire = pkgs.haskellPackages.proto3-wire;
+
+in proto3-wire.env.overrideAttrs (old: {
+  buildInputs = (old.buildInputs or []) ++ [
+    pkgs.cabal-install
+  ];
+})

--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -88,7 +88,6 @@ import qualified Data.ByteString.Lazy    as BL
 import           Data.Foldable           ( foldl' )
 import qualified Data.IntMap.Strict      as M -- TODO intmap
 import           Data.Maybe              ( fromMaybe )
-import           Data.Monoid             ( (<>) )
 import           Data.Serialize.Get      ( Get, getWord8, getInt32le
                                          , getInt64le, getWord32le, getWord64le
                                          , runGet )

--- a/src/Proto3/Wire/Tutorial.hs
+++ b/src/Proto3/Wire/Tutorial.hs
@@ -167,7 +167,6 @@
 module Proto3.Wire.Tutorial where
 
 import           Data.ByteString         ( ByteString )
-import           Data.Monoid             ( (<>) )
 import           Data.Text.Lazy          ( Text )
 import           Data.Word               ( Word64 )
 

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -21,7 +21,7 @@
 
 module Main where
 
-import           Control.Arrow         ( (&&&), first, second )
+import           Control.Arrow         ( (&&&), second )
 import           Control.Monad         ( guard, void )
 import           Control.Monad.Trans.State ( StateT(..) )
 import qualified Data.Bits             as Bits
@@ -30,7 +30,6 @@ import qualified Data.ByteString.Lazy  as BL
 import qualified Data.ByteString.Builder.Internal as BBI
 import           Data.Either           ( isLeft )
 import           Data.Maybe            ( fromMaybe )
-import           Data.Monoid           ( (<>) )
 import           Data.Int
 import           Data.List             ( group )
 import qualified Data.Text.Lazy        as T
@@ -41,14 +40,12 @@ import           Foreign               ( sizeOf )
 import           Proto3.Wire
 import qualified Proto3.Wire.Builder   as Builder
 import qualified Proto3.Wire.Reverse   as Reverse
-import qualified Proto3.Wire.Reverse.Prim as Prim
 import qualified Proto3.Wire.Encode    as Encode
 import qualified Proto3.Wire.Decode    as Decode
 
 import qualified Test.DocTest
 import           Test.QuickCheck       ( (===), Arbitrary )
 import           Test.Tasty
-import           Test.Tasty.HUnit      ( (@=?) )
 import qualified Test.Tasty.HUnit      as HU
 import qualified Test.Tasty.QuickCheck as QC
 
@@ -249,9 +246,9 @@ buildSingleChunk = HU.testCase "Legacy Builder creates a single chunk" $ do
 
 parseBytes :: Int64 -> StateT BL.ByteString Maybe BL.ByteString
 parseBytes n = StateT $ \bl -> do
-  let (before, after) = BL.splitAt n bl
-  guard (BL.length before == n)
-  pure (before, after)
+  let (prefix, suffix) = BL.splitAt n bl
+  guard (BL.length prefix == n)
+  pure (prefix, suffix)
 
 -- | Parses a big-endian 64-bit unsigned integer.
 parseWord64BE :: StateT BL.ByteString Maybe Word64


### PR DESCRIPTION
I've updated the pinned nixpkgs to release 21.05. The nixpkgs that was pinned previously didn't seem to [support big sur 11](https://github.com/NixOS/nixpkgs/issues/91748) which made it impossible to enter into a nix shell or build the package.