### PR TITLE
Allow doctest 0.20.0

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -55,7 +55,7 @@ test-suite tests
   build-depends:       base >=4.9 && <=5.0,
                        bytestring >=0.10.6.0 && <0.11.0,
                        cereal >= 0.5.1 && <0.6,
-                       doctest >= 0.7.0 && <0.18,
+                       doctest >= 0.7.0 && <0.21.0,
                        proto3-wire,
                        QuickCheck >=2.8 && <3.0,
                        tasty >= 0.11 && <1.5,


### PR DESCRIPTION
This is related to https://github.com/haskell/cabal/issues/4500#issuecomment-969061372 . Here is the changelog https://hackage.haskell.org/package/doctest-0.20.0/changelog .