### PR TITLE
Support GHC 9.2

### DIFF
--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -9,7 +9,7 @@ pkgsNew: pkgsOld:
         (old.overrides or (_: _: {}))
         (haskellPackagesFinal: haskellPackagesPrev: {
           proto3-wire = haskellPackagesFinal.callCabal2nix "proto3-wire" ../. { };
-          word-compat = haskellPackagesFinal.callPackage (import ./word-compat.nix);
+          word-compat = haskellPackagesFinal.callPackage ./word-compat.nix { };
         });
   });
 }

--- a/nix/haskell-packages.nix
+++ b/nix/haskell-packages.nix
@@ -8,7 +8,8 @@ pkgsNew: pkgsOld:
       pkgsOld.lib.composeExtensions
         (old.overrides or (_: _: {}))
         (haskellPackagesFinal: haskellPackagesPrev: {
-          proto3-wire = haskellPackagesPrev.callCabal2nix "proto3-wire" ../. { };
+          proto3-wire = haskellPackagesFinal.callCabal2nix "proto3-wire" ../. { };
+          word-compat = haskellPackagesFinal.callPackage (import ./word-compat.nix);
         });
   });
 }

--- a/nix/word-compat.nix
+++ b/nix/word-compat.nix
@@ -1,13 +1,8 @@
-{ mkDerivation, base, fetchgit, ghc-prim, lib }:
+{ mkDerivation, base, ghc-prim, lib }:
 mkDerivation {
   pname = "word-compat";
-  version = "0.0.1";
-  src = fetchgit {
-    url = "https://github.com/j6carey/word-compat";
-    sha256 = "03g8lz806h3m15dg6894snyizav76skkfw9bxxa1b5wlyq6aqag1";
-    rev = "1d3147cb6789b4ad67285dfbe8b2384c8842b6f1";
-    fetchSubmodules = true;
-  };
+  version = "0.0.2";
+  sha256 = "36e5a1a17f20935f55bf274fb52cbb028d301fd48d814f574d3171ccc6bc9f98";
   libraryHaskellDepends = [ base ghc-prim ];
   description = "Compatibility shim for the Int/Word internal change in GHC 9.2";
   license = lib.licenses.bsd3;

--- a/nix/word-compat.nix
+++ b/nix/word-compat.nix
@@ -3,9 +3,9 @@ mkDerivation {
   pname = "word-compat";
   version = "0.0.1";
   src = fetchgit {
-    url = "https://github.com/fumieval/word-compat";
-    sha256 = "13370fp55ms3bmyip83vav33jasggz04sksy61ypd0fm5yirpj7x";
-    rev = "c02432cea08bc8037fe8f1bbfc7a026bbddff75e";
+    url = "https://github.com/j6carey/word-compat";
+    sha256 = "03g8lz806h3m15dg6894snyizav76skkfw9bxxa1b5wlyq6aqag1";
+    rev = "1d3147cb6789b4ad67285dfbe8b2384c8842b6f1";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [ base ghc-prim ];

--- a/nix/word-compat.nix
+++ b/nix/word-compat.nix
@@ -1,0 +1,14 @@
+{ mkDerivation, base, fetchgit, ghc-prim, lib }:
+mkDerivation {
+  pname = "word-compat";
+  version = "0.0.1";
+  src = fetchgit {
+    url = "https://github.com/fumieval/word-compat";
+    sha256 = "15ffpvza5jppcnracqa8shylr8ds6lvb4janry9yyyyw2a3h2cyb";
+    rev = "3eb157b229af035c4a35a0524d56acdec50ba6c4";
+    fetchSubmodules = true;
+  };
+  libraryHaskellDepends = [ base ghc-prim ];
+  description = "Compatibility shim for the Int/Word internal change in GHC 9.2";
+  license = lib.licenses.bsd3;
+}

--- a/nix/word-compat.nix
+++ b/nix/word-compat.nix
@@ -4,8 +4,8 @@ mkDerivation {
   version = "0.0.1";
   src = fetchgit {
     url = "https://github.com/fumieval/word-compat";
-    sha256 = "15ffpvza5jppcnracqa8shylr8ds6lvb4janry9yyyyw2a3h2cyb";
-    rev = "3eb157b229af035c4a35a0524d56acdec50ba6c4";
+    sha256 = "13370fp55ms3bmyip83vav33jasggz04sksy61ypd0fm5yirpj7x";
+    rev = "c02432cea08bc8037fe8f1bbfc7a026bbddff75e";
     fetchSubmodules = true;
   };
   libraryHaskellDepends = [ base ghc-prim ];

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -37,7 +37,8 @@ library
                        transformers >=0.5.6.2 && <0.6,
                        unordered-containers >= 0.1.0.0 && <0.3,
                        vector >=0.12.0.2 && <0.13,
-                       QuickCheck >=2.8 && <3.0
+                       QuickCheck >=2.8 && <3.0,
+                       word-compat >= 0.0 && <0.1
 
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Proto3/Wire/Reverse/Prim.hs
+++ b/src/Proto3/Wire/Reverse/Prim.hs
@@ -121,8 +121,7 @@ import           GHC.Int                       ( Int(..) )
 import           GHC.Ptr                       ( Ptr(..) )
 import           GHC.TypeLits                  ( KnownNat, Nat,
                                                  type (+), natVal' )
-import           GHC.Word                      ( Word(..), Word8(..),
-                                                 Word32(..), Word64(..) )
+import           GHC.Word.Compat
 import           Parameterized.Data.Semigroup  ( PNullary, PSemigroup(..),
                                                  (&<>) )
 import           Parameterized.Data.Monoid     ( PMEmpty(..) )

--- a/src/Proto3/Wire/Reverse/Prim.hs
+++ b/src/Proto3/Wire/Reverse/Prim.hs
@@ -121,7 +121,8 @@ import           GHC.Int                       ( Int(..) )
 import           GHC.Ptr                       ( Ptr(..) )
 import           GHC.TypeLits                  ( KnownNat, Nat,
                                                  type (+), natVal' )
-import           GHC.Word.Compat
+import           GHC.Word.Compat               ( Word(..), Word8(..),
+                                                 Word32(..), Word64(..) )
 import           Parameterized.Data.Semigroup  ( PNullary, PSemigroup(..),
                                                  (&<>) )
 import           Parameterized.Data.Monoid     ( PMEmpty(..) )

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
-resolver: lts-7.4
+resolver: lts-19.0
+
+extra-deps:
+  - word-compat-0.0.2


### PR DESCRIPTION
Restores 4d5391981bdc4d002d33959b6765f67eb7065351 ,
but based on a newer version of word-compat (0.0.2) in order
to avoid build failure.