### PR TITLE
Require word-compat >=0.0.2

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -38,7 +38,7 @@ library
                        unordered-containers >= 0.1.0.0 && <0.3,
                        vector >=0.12.0.2 && <0.13,
                        QuickCheck >=2.8 && <3.0,
-                       word-compat >= 0.0 && <0.1
+                       word-compat >= 0.0.2 && <0.1
 
   hs-source-dirs:      src
   default-language:    Haskell2010


### PR DESCRIPTION
We know that builds fail with earlier versions.