### PR TITLE
Allow hashable 1.5

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -29,7 +29,7 @@ library
                        containers >=0.5 && < 0.7,
                        deepseq ==1.4.*,
                        ghc-prim >=0.5.3 && <0.8,
-                       hashable <1.4,
+                       hashable <1.5,
                        parameterized >=0.5.0.0 && <1,
                        primitive >=0.6.4 && <0.8,
                        safe ==0.3.*,


### PR DESCRIPTION
This change enables building proto3-suite with latest hashable.