### PR TITLE
Allow bytestring-0.11 and ghc-prim-0.9

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -24,11 +24,11 @@ library
   other-modules:       Proto3.Wire.Reverse.Internal
                        Proto3.Wire.Reverse.Width
   build-depends:       base >=4.12 && <=5.0,
-                       bytestring >=0.10.6.0 && <0.11.0,
+                       bytestring >=0.10.6.0 && <0.12.0,
                        cereal >= 0.5.1 && <0.6,
                        containers >=0.5 && < 0.7,
                        deepseq ==1.4.*,
-                       ghc-prim >=0.5.3 && <0.8,
+                       ghc-prim >=0.5.3 && <0.9,
                        hashable <1.5,
                        parameterized >=0.5.0.0 && <1,
                        primitive >=0.6.4 && <0.8,

--- a/src/Proto3/Wire/Reverse/Prim.hs
+++ b/src/Proto3/Wire/Reverse/Prim.hs
@@ -107,9 +107,6 @@ import           Data.Char                     ( ord )
 import           Data.Int                      ( Int8, Int16, Int32, Int64 )
 import           Data.Kind                     ( Type )
 import qualified Data.Vector.Generic
-import           Data.Word                     ( Word16,
-                                                 byteSwap16, byteSwap32,
-                                                 byteSwap64 )
 import           Foreign                       ( Storable(..) )
 import           GHC.Exts                      ( Addr#, Int#, Proxy#,
                                                  RealWorld, State#, (+#),
@@ -121,8 +118,7 @@ import           GHC.Int                       ( Int(..) )
 import           GHC.Ptr                       ( Ptr(..) )
 import           GHC.TypeLits                  ( KnownNat, Nat,
                                                  type (+), natVal' )
-import           GHC.Word.Compat               ( Word(..), Word8(..),
-                                                 Word32(..), Word64(..) )
+import           GHC.Word.Compat
 import           Parameterized.Data.Semigroup  ( PNullary, PSemigroup(..),
                                                  (&<>) )
 import           Parameterized.Data.Monoid     ( PMEmpty(..) )


### PR DESCRIPTION
This change enables building with ghc-9.2 by fixing this error:

```
src/Proto3/Wire/Reverse/Prim.hs:829:54: error:
    Not in scope: data constructor ‘W32#’
    Perhaps you want to add ‘W32#’ to the import list in the import of
    ‘GHC.Word.Compat’
    (src/Proto3/Wire/Reverse/Prim.hs:(124,1)-(125,73)).
    |
829 |     shR s = case fromIntegral (shiftR (W64# x) s) of W32# y -> y
    |                                                      ^^^^
```

But adding the import does not seems to work, so this change
replaces Data.Word with GHC.Word.Compat and removes the explicit import
list.