### PR TITLE
Improve performance of toMap when keys are mostly sorted

### DIFF
--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -1,0 +1,85 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+
+module Main where
+
+import qualified Data.ByteString               as B
+import qualified Data.ByteString.Lazy          as BL
+import qualified Proto3.Wire.Decode as De
+import qualified Proto3.Wire.Encode as En
+import Proto3.Wire
+
+import Control.Applicative (liftA3)
+import Data.Maybe
+import Data.Word
+import Data.IORef
+
+import Criterion (bench)
+import qualified Criterion as C
+import Criterion.Main (defaultMain)
+
+intTreeParser :: De.Parser De.RawMessage Word64
+intTreeParser = liftA3 combine
+    (De.at (De.repeated De.fixed64) (FieldNumber 0))
+    (De.at (De.embedded intTreeParser) (FieldNumber 1))
+    (De.at (De.embedded intTreeParser) (FieldNumber 2))
+  where
+    combine xs y z = sum xs + fromMaybe 0 y + fromMaybe 0 z
+
+detRandom :: [Word64]
+detRandom =
+  [ 159, 207, 87, 180, 236,
+    227, 133, 16, 164, 43,
+    245, 128, 249, 170, 216,
+    181, 164, 162, 239, 249,
+    76, 237, 197, 246, 209,
+    231, 124, 154, 55, 64,
+    4, 114, 79, 199, 252,
+    163, 116, 237, 209, 138,
+    240, 148, 212, 224, 88,
+    131, 122, 114, 158, 97,
+    186, 3, 223, 230, 223,
+    207, 93, 168, 48, 130,
+    77, 122, 30, 222, 221,
+    224, 243, 19, 175, 61,
+    112, 246, 201, 57, 185,
+    19, 128, 129, 138, 209,
+    4, 153, 196, 238, 72,
+    254, 157, 233, 81, 30,
+    106, 249, 57, 214, 104,
+    171, 146, 175, 185, 192
+    ]
+
+pullInt :: IORef [Word64] -> IO Word64
+pullInt xs = do
+  xs' <- readIORef xs
+  case xs' of
+    [] -> pure 7
+    x : xs' -> do
+      writeIORef xs xs'
+      pure x
+
+mkTree0 :: IORef [Word64] -> IO En.MessageBuilder
+mkTree0 ints = do
+  shouldFork <- (\(i :: Word64) -> (i `mod` 8) < 5) <$> pullInt ints
+  if shouldFork
+    then do
+      i <- En.fixed64 (FieldNumber 0) <$> pullInt ints
+      left <- En.embedded (FieldNumber 1) <$> mkTree0 ints
+      right <- En.embedded (FieldNumber 2) <$> mkTree0 ints
+      pure (i <> left <> right)
+    else pure mempty
+
+mkTree :: IO B.ByteString
+mkTree = BL.toStrict . En.toLazyByteString <$> (mkTree0 =<< newIORef detRandom)
+
+decode :: B.ByteString -> IO (Maybe Word64)
+decode = pure . toMaybe . De.parse intTreeParser
+  where
+    toMaybe (Left _) = Nothing
+    toMaybe (Right x) = Just x
+
+main :: IO ()
+main =
+  defaultMain
+    [ bench "Parse int tree" $ C.perRunEnv mkTree decode ]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeApplications #-}
 
 
 module Main where
@@ -12,7 +13,8 @@ import qualified Proto3.Wire.Decode as De
 import qualified Proto3.Wire.Encode as En
 import Proto3.Wire
 
-import Control.Applicative (liftA3)
+import Control.Applicative (liftA2, liftA3)
+import Control.Monad (forM)
 import Data.Maybe
 import Data.Word
 import Data.IORef
@@ -24,6 +26,8 @@ import Criterion.Main (defaultMain)
 data Tree a = Leaf | Branch a (Tree a) (Tree a)
   deriving (Eq, Functor)
 
+data Rose a = Bud | Rose a [Rose a]
+
 instance Foldable Tree where
   foldr _ z Leaf = z
   foldr f z (Branch a t1 t2) = foldr f (f a (foldr f z t2)) t1
@@ -34,6 +38,10 @@ instance Foldable Tree where
         !a2 = sum t2
     in a + a1 + a2
 
+instance Foldable Rose where
+  foldMap f Bud = mempty
+  foldMap f (Rose x rs) = f x <> ((foldMap.foldMap) f rs)
+
 intTreeParser :: De.Parser De.RawMessage (Tree Word64)
 intTreeParser = liftA3 combine
     (De.at (De.repeated De.fixed64) (FieldNumber 0))
@@ -41,6 +49,11 @@ intTreeParser = liftA3 combine
     (De.at (De.one (De.embedded' intTreeParser) Leaf) (FieldNumber 2))
   where
     combine xs y z = Branch (sum xs) y z
+
+intRoseParser :: De.Parser De.RawMessage (Rose Word64)
+intRoseParser = liftA2 (Rose @Word64)
+  (De.at (De.one De.fixed64 0) (FieldNumber 0))
+  (De.at (De.repeated (De.embedded' intRoseParser)) (FieldNumber 1))
 
 detRandom :: [Word64]
 detRandom = concat . replicate 10 $
@@ -110,32 +123,53 @@ pullInt :: IORef [Word64] -> IO Word64
 pullInt xs = do
   xs' <- readIORef xs
   case xs' of
-    [] -> pure 7
+    [] -> pure (-1)
     x : xs' -> do
       writeIORef xs xs'
       pure x
 
-mkTree0 :: IORef [Word64] -> IO En.MessageBuilder
+mkTree0 :: IO Word64 -> IO En.MessageBuilder
 mkTree0 ints = do
-  shouldFork <- (\(i :: Word64) -> (i `mod` 8) < 6) <$> pullInt ints
+  shouldFork <- (\(i :: Word64) -> (i `mod` 8) < 6) <$> ints
   if shouldFork
     then do
-      i <- En.fixed64 (FieldNumber 0) <$> pullInt ints
+      i <- En.fixed64 (FieldNumber 0) <$> ints
       left <- En.embedded (FieldNumber 1) <$> mkTree0 ints
       right <- En.embedded (FieldNumber 2) <$> mkTree0 ints
       pure (i <> left <> right)
     else pure mempty
 
-mkTree :: IO B.ByteString
-mkTree = BL.toStrict . En.toLazyByteString <$> (mkTree0 =<< newIORef detRandom)
+mkRose0 :: IO Word64 -> IO En.MessageBuilder
+mkRose0 ints = do
+  next <- fromIntegral <$> ints
+  if next == -1 then pure mempty else do
+    let nBranches = next `mod` 9
+    if nBranches == 0 then pure mempty else do
+      loc <- (\i -> (i `mod` nBranches)) . fromIntegral <$> ints
+      i <- En.fixed64 (FieldNumber 0) <$> ints
+      rs1 <- forM (replicate loc ()) $ \() ->
+        En.embedded (FieldNumber 1) <$> mkTree0 ints
+      rs2 <- forM (replicate (nBranches - loc) ()) $ \() ->
+        En.embedded (FieldNumber 1) <$> mkTree0 ints
+      pure (mconcat rs1 <> i <> mconcat rs2)
 
-decode :: B.ByteString -> IO (Maybe Word64)
-decode = pure . fmap sum . toMaybe . De.parse intTreeParser
+mkTree :: IO B.ByteString
+mkTree = BL.toStrict . En.toLazyByteString <$> (mkTree0 . pullInt =<< newIORef detRandom)
+
+mkRose :: IO B.ByteString
+mkRose = BL.toStrict . En.toLazyByteString <$> (mkRose0 . pullInt =<< newIORef detRandom)
+
+decode :: Foldable f => De.Parser De.RawMessage (f Word64) -> B.ByteString -> IO (Maybe Word64)
+decode p = pure . fmap sum . toMaybe . De.parse p
   where
     toMaybe (Left _) = Nothing
     toMaybe (Right x) = Just x
 
+unwrap :: (Functor m, Foldable f) => m (f a) -> m a
+unwrap = fmap (foldr1 const)
+
 main :: IO ()
 main =
   defaultMain
-    [ bench "Parse int tree" $ C.perRunEnv mkTree decode ]
+    [ bench "Parse int tree" $ C.perRunEnv mkTree (unwrap . decode intTreeParser)
+    , bench "Parse int rose tree" $ C.perRunEnv mkRose (unwrap . decode intRoseParser)]

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -26,7 +26,7 @@ data Tree a = Leaf | Branch a (Tree a) (Tree a)
 
 instance Foldable Tree where
   foldr _ z Leaf = z
-  foldr f z (Branch a t1 t2) = foldr f (foldr f z t2) t1
+  foldr f z (Branch a t1 t2) = foldr f (f a (foldr f z t2)) t1
 
   sum Leaf = 0
   sum (Branch a t1 t2) =

--- a/bench/Main.hs
+++ b/bench/Main.hs
@@ -37,15 +37,54 @@ instance Foldable Tree where
 intTreeParser :: De.Parser De.RawMessage (Tree Word64)
 intTreeParser = liftA3 combine
     (De.at (De.repeated De.fixed64) (FieldNumber 0))
-    (De.at (De.embedded intTreeParser) (FieldNumber 1))
-    (De.at (De.embedded intTreeParser) (FieldNumber 2))
+    (De.at (De.one (De.embedded' intTreeParser) Leaf) (FieldNumber 1))
+    (De.at (De.one (De.embedded' intTreeParser) Leaf) (FieldNumber 2))
   where
-    combine xs (Just y) (Just z) = Branch (sum xs) y z
-    combine _ _ _ = Leaf
+    combine xs y z = Branch (sum xs) y z
 
 detRandom :: [Word64]
-detRandom =
-  [ 159, 207, 87, 180, 236,
+detRandom = concat . replicate 10 $
+  [ 227, 133, 16, 164, 43,
+    159, 207, 87, 180, 236,
+    245, 128, 249, 170, 216,
+    181, 164, 162, 239, 249,
+    76, 237, 197, 246, 209,
+    231, 124, 154, 55, 64,
+    4, 114, 79, 199, 252,
+    163, 116, 237, 209, 138,
+    240, 148, 212, 224, 88,
+    131, 122, 114, 158, 97,
+    186, 3, 223, 230, 223,
+    207, 93, 168, 48, 130,
+    77, 122, 30, 222, 221,
+    224, 243, 19, 175, 61,
+    112, 246, 201, 57, 185,
+    19, 128, 129, 138, 209,
+    4, 153, 196, 238, 72,
+    254, 157, 233, 81, 30,
+    106, 249, 57, 214, 104,
+    171, 146, 175, 185, 192,
+    159, 207, 87, 180, 236,
+    227, 133, 16, 164, 43,
+    245, 128, 249, 170, 216,
+    181, 164, 162, 239, 249,
+    76, 237, 197, 246, 209,
+    231, 124, 154, 55, 64,
+    4, 114, 79, 199, 252,
+    163, 116, 237, 209, 138,
+    240, 148, 212, 224, 88,
+    131, 122, 114, 158, 97,
+    186, 3, 223, 230, 223,
+    207, 93, 168, 48, 130,
+    77, 122, 30, 222, 221,
+    224, 243, 19, 175, 61,
+    112, 246, 201, 57, 185,
+    19, 128, 129, 138, 209,
+    4, 153, 196, 238, 72,
+    254, 157, 233, 81, 30,
+    106, 249, 57, 214, 104,
+    171, 146, 175, 185, 192,
+    159, 207, 87, 180, 236,
     227, 133, 16, 164, 43,
     245, 128, 249, 170, 216,
     181, 164, 162, 239, 249,
@@ -78,7 +117,7 @@ pullInt xs = do
 
 mkTree0 :: IORef [Word64] -> IO En.MessageBuilder
 mkTree0 ints = do
-  shouldFork <- (\(i :: Word64) -> (i `mod` 8) < 5) <$> pullInt ints
+  shouldFork <- (\(i :: Word64) -> (i `mod` 8) < 6) <$> pullInt ints
   if shouldFork
     then do
       i <- En.fixed64 (FieldNumber 0) <$> pullInt ints

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -65,3 +65,11 @@ test-suite tests
                        text >= 0.2 && <1.3,
                        transformers >=0.5.6.2 && <0.6,
                        vector >=0.12.0.2 && <0.13
+
+benchmark bench
+  type:                exitcode-stdio-1.0
+  main-is:             Main.hs
+  build-depends:       base >= 4 && < 5, bytestring, random, criterion, proto3-wire
+  hs-source-dirs:      bench
+  ghc-options:         -O2 -Wall -fobject-code -ddump-simpl -ddump-to-file
+

--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -127,7 +127,26 @@ data ParsedField = VarintField Word64
 -- fromList [(1,[6,3]),(2,[4])]
 --
 toMap :: [(FieldNumber, v)] -> M.IntMap [v]
-toMap kvs0 = M.fromListWith (<>) . map (fmap (:[])) . map (first (fromIntegral . getFieldNumber)) $ kvs0
+toMap kvs0 = makeMap . map (first (fromIntegral . getFieldNumber)) $ kvs0
+  where
+    makeMap :: [(Int, v)] -> M.IntMap [v]
+    makeMap = close . foldl' combineSeen (M.empty, Nothing)
+
+    close (m, Nothing) = m
+    close (m, Just (k, v)) = M.insert k v m
+
+    -- If keys are in order, then we don't have to make any lookups,
+    -- we just maintain the active element.
+    -- Out of order keys will lookup in the map
+    combineSeen :: (M.IntMap [v], Maybe (Int, [v])) -> (Int, v) -> (M.IntMap [v], Maybe (Int, [v]))
+    combineSeen (_, Nothing) (k1, a1) = (M.empty, Just (k1, [a1]))
+    combineSeen (m, Just (k2, as)) (k1, a1) =
+      case compare k1 k2 of
+        EQ -> (m, Just (k1, a1 : as))
+        LT -> let !m' = M.insertWith (<>) k1 [a1] m
+              in (m', Just (k2, as))
+        GT -> let !m' = M.insert k2 as m
+              in (m', Just (k1, [a1]))
 
 -- | Parses data in the raw wire format into an untyped 'Map' representation.
 decodeWire :: B.ByteString -> Either String [(FieldNumber, ParsedField)]

--- a/src/Proto3/Wire/Decode.hs
+++ b/src/Proto3/Wire/Decode.hs
@@ -141,14 +141,10 @@ toMap kvs0 = makeMap . map (first (fromIntegral . getFieldNumber)) $ kvs0
     combineSeen :: Maybe (M.IntMap [v], Int, [v]) -> (Int, v) -> Maybe (M.IntMap [v], Int, [v])
     combineSeen Nothing (k1, a1) = Just (M.empty, k1, [a1])
     combineSeen (Just (m, k2, as)) (k1, a1) =
-      case compare k1 k2 of
-        -- NOTE: this is a foldl, so this list will
-        -- be in reverse order (intentionally)
-        EQ -> Just (m, k1, a1 : as)
-        LT -> let !m' = M.insertWith (<>) k1 [a1] m
-              in Just (m', k2, as)
-        GT -> let !m' = M.insert k2 as m
-              in Just (m', k1, [a1])
+      if k1 == k2
+        then Just (m, k1, a1 : as)
+        else let !m' = M.insertWith (<>) k2 as m
+             in Just (m', k1, [a1])
 
 -- | Parses data in the raw wire format into an untyped 'Map' representation.
 decodeWire :: B.ByteString -> Either String [(FieldNumber, ParsedField)]


### PR DESCRIPTION
There's probably more work needed for benchmarks, but this shows around 50% total speedup of parsing on a simple binary tree.  This is an improvement because it increases fusion, whereas the original can never fuse

Old:
benchmarking Parse int tree
time                 773.3 μs   (769.8 μs .. 776.9 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 771.7 μs   (770.1 μs .. 775.9 μs)
std dev              7.755 μs   (3.902 μs .. 14.59 μs)
benchmarking Parse int rose tree
time                 1.170 μs   (1.161 μs .. 1.180 μs)
                     1.000 R²   (0.999 R² .. 1.000 R²)
mean                 1.171 μs   (1.162 μs .. 1.188 μs)
std dev              23.25 ns   (14.62 ns .. 32.45 ns)
variance introduced by outliers: 21% (moderately inflated)

New:
benchmarking Parse int tree
time                 521.7 μs   (520.3 μs .. 523.3 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 521.7 μs   (520.4 μs .. 523.0 μs)
std dev              4.302 μs   (3.596 μs .. 5.186 μs)

benchmarking Parse int rose tree
time                 1.064 μs   (1.061 μs .. 1.069 μs)
                     1.000 R²   (1.000 R² .. 1.000 R²)
mean                 1.064 μs   (1.060 μs .. 1.069 μs)
std dev              10.01 ns   (6.752 ns .. 14.37 ns)

Speedup:
* In-order Binary tree -> 48%
* Mixed-order Rose tree -> 10%

Geometric Mean: 28%