### PR TITLE
Allow bytestring-0.11 in test

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -54,7 +54,7 @@ test-suite tests
   hs-source-dirs:      test
   default-language:    Haskell2010
   build-depends:       base >=4.9 && <=5.0,
-                       bytestring >=0.10.6.0 && <0.11.0,
+                       bytestring >=0.10.6.0 && <0.12.0,
                        cereal >= 0.5.1 && <0.6,
                        doctest >= 0.7.0 && <0.21.0,
                        proto3-wire,


### PR DESCRIPTION
This change enables running proto3-wire test with ghc-9.2.