### PR TITLE
Tests reuse encoding buffer

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -12,6 +12,12 @@ cabal-version:       >=1.10
 extra-source-files:  CHANGELOG.md
 
 library
+  ghc-options:
+    -ddump-to-file
+    -ddump-simpl
+    -dsuppress-uniques
+    -ddump-stg
+
   exposed-modules:     Proto3.Wire
                        Proto3.Wire.Builder
                        Proto3.Wire.Class
@@ -21,8 +27,8 @@ library
                        Proto3.Wire.Reverse.Prim
                        Proto3.Wire.Tutorial
                        Proto3.Wire.Types
-  other-modules:       Proto3.Wire.Reverse.Internal
-                       Proto3.Wire.Reverse.Width
+                       Proto3.Wire.Reverse.Internal
+  other-modules:       Proto3.Wire.Reverse.Width
   build-depends:       base >=4.12 && <=5.0,
                        bytestring >=0.10.6.0 && <0.12.0,
                        cereal >= 0.5.1 && <0.6,

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -13,10 +13,6 @@ extra-source-files:  CHANGELOG.md
 
 library
   ghc-options:
-    -ddump-to-file
-    -ddump-simpl
-    -dsuppress-uniques
-    -ddump-stg
 
   exposed-modules:     Proto3.Wire
                        Proto3.Wire.Builder

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -35,6 +35,7 @@ module Proto3.Wire.Reverse.Internal
     , SealedState (SealedState, sealedSB, totalSB, stateVarSB, statePtrSB, recycledSB)
     , sealBuffer
     , smallChunkSize
+    , writeState
     , writeSpace
     , metaDataSize
     , withUnused

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -30,6 +30,8 @@ module Proto3.Wire.Reverse.Internal
     , fromBuildR
     , etaBuildR
     , runBuildR
+    , newBuffer
+    , smallChunkSize
     , withUnused
     , withTotal
     , withLengthOf

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -35,6 +35,8 @@ module Proto3.Wire.Reverse.Internal
     , SealedState (SealedState, sealedSB, totalSB, stateVarSB, statePtrSB, recycledSB)
     , sealBuffer
     , smallChunkSize
+    , writeSpace
+    , metaDataSize
     , withUnused
     , withTotal
     , readTotal

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -24,7 +24,7 @@
 
 module Proto3.Wire.Reverse.Internal
     ( BuildR (..)
-    , BuildRState (..),
+    , BuildRState (..)
     , appendBuildR
     , foldlRVector
     , toBuildR

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -31,6 +31,8 @@ module Proto3.Wire.Reverse.Internal
     , etaBuildR
     , runBuildR
     , newBuffer
+    , SealedState (SealedState, sealedSB, totalSB, stateVarSB, statePtrSB, recycledSB)
+    , sealBuffer
     , smallChunkSize
     , withUnused
     , withTotal

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -35,7 +35,9 @@ module Proto3.Wire.Reverse.Internal
     , SealedState (SealedState, sealedSB, totalSB, stateVarSB, statePtrSB, recycledSB)
     , sealBuffer
     , smallChunkSize
+    , readState
     , writeState
+    , readSpace
     , writeSpace
     , metaDataSize
     , metaDataAlign

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -37,6 +37,7 @@ module Proto3.Wire.Reverse.Internal
     , smallChunkSize
     , withUnused
     , withTotal
+    , readTotal
     , withLengthOf
     , withLengthOf#
     , reallocate

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -31,13 +31,12 @@ module Proto3.Wire.Reverse.Internal
     , fromBuildR
     , etaBuildR
     , runBuildR
-    , newBuffer
     , SealedState (SealedState, sealedSB, totalSB, stateVarSB, statePtrSB, recycledSB)
     , sealBuffer
     , smallChunkSize
     , readState
-    , writeState
     , readSpace
+    , writeState
     , writeSpace
     , metaDataSize
     , metaDataAlign

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -23,7 +23,8 @@
 {-# LANGUAGE UnboxedTuples #-}
 
 module Proto3.Wire.Reverse.Internal
-    ( BuildR(..)
+    ( BuildR (..)
+    , BuildRState (..),
     , appendBuildR
     , foldlRVector
     , toBuildR

--- a/src/Proto3/Wire/Reverse/Internal.hs
+++ b/src/Proto3/Wire/Reverse/Internal.hs
@@ -38,6 +38,7 @@ module Proto3.Wire.Reverse.Internal
     , writeState
     , writeSpace
     , metaDataSize
+    , metaDataAlign
     , withUnused
     , withTotal
     , readTotal


### PR DESCRIPTION
This PR exposes the module `Proto3.Wire.Reverse.Internal` and exports some internal functions that are needed in order to support changes in [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt/pull/42).