### PR TITLE
Derive Data and Generic instances for FieldNumber

### DIFF
--- a/src/Proto3/Wire/Types.hs
+++ b/src/Proto3/Wire/Types.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE DeriveDataTypeable         #-}
+{-# LANGUAGE DeriveGeneric              #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {-
@@ -27,8 +29,10 @@ module Proto3.Wire.Types
     ) where
 
 import           Control.DeepSeq ( NFData )
+import           Data.Data       ( Data )
 import           Data.Hashable   ( Hashable )
 import           Data.Word       ( Word64 )
+import           GHC.Generics    ( Generic )
 import           Test.QuickCheck ( Arbitrary(..), choose )
 
 -- | A 'FieldNumber' identifies a field inside a protobufs message.
@@ -36,14 +40,15 @@ import           Test.QuickCheck ( Arbitrary(..), choose )
 -- This library makes no attempt to generate these automatically, or even make
 -- sure that field numbers are provided in increasing order. Such things are
 -- left to other, higher-level libraries.
-newtype FieldNumber = FieldNumber { getFieldNumber :: Word64 }
-    deriving (Eq, Ord, Enum, Hashable, NFData, Num)
+newtype FieldNumber = FieldNumber
+  { getFieldNumber :: Word64 }
+  deriving (Bounded, Data, Enum, Eq, Generic, Hashable, NFData, Num, Ord)
 
 instance Show FieldNumber where
-    show (FieldNumber n) = show n
+  show (FieldNumber n) = show n
 
 instance Arbitrary FieldNumber where
-  arbitrary = fmap FieldNumber $ choose (1, 536870911)
+  arbitrary = FieldNumber <$> choose (1, 536870911)
 
 -- | Create a 'FieldNumber' given the (one-based) integer which would label
 -- the field in the corresponding .proto file.
@@ -52,5 +57,9 @@ fieldNumber = FieldNumber
 
 -- | The (non-deprecated) wire types identified by the Protocol
 -- Buffers specification.
-data WireType = Varint | Fixed32 | Fixed64 | LengthDelimited
-    deriving (Show, Eq, Ord)
+data WireType
+  = Varint
+  | Fixed32
+  | Fixed64
+  | LengthDelimited
+  deriving (Bounded, Data, Enum, Eq, Generic, Ord, Show)


### PR DESCRIPTION
This PR derives `Data` and `Generic` instances for the `Proto3.Wire.Types.FieldNumber` type. Our [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt) currently depends on these instances and obtains them with orphaned standalone deriving clauses.