### PR TITLE
Add derived `Lift` instances 

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -35,6 +35,7 @@ library
                        parameterized >=0.5.0.0 && <1,
                        primitive >=0.6.4 && <0.8,
                        safe ==0.3.*,
+                       template-haskell >= 2.15.0 && < 2.20,
                        text >= 0.2 && <1.3,
                        text-short ==0.1.*,
                        transformers >=0.5.6.2 && <0.6,

--- a/src/Proto3/Wire/Types.hs
+++ b/src/Proto3/Wire/Types.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DeriveDataTypeable         #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveLift                 #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 {-
@@ -28,12 +29,13 @@ module Proto3.Wire.Types
     , WireType(..)
     ) where
 
-import           Control.DeepSeq ( NFData )
-import           Data.Data       ( Data )
-import           Data.Hashable   ( Hashable )
-import           Data.Word       ( Word64 )
-import           GHC.Generics    ( Generic )
-import           Test.QuickCheck ( Arbitrary(..), choose )
+import           Control.DeepSeq            ( NFData )
+import           Data.Data                  ( Data )
+import           Data.Hashable              ( Hashable )
+import           Data.Word                  ( Word64 )
+import           GHC.Generics               ( Generic )
+import           Language.Haskell.TH.Syntax ( Lift )
+import           Test.QuickCheck            ( Arbitrary(..), choose )
 
 -- | A 'FieldNumber' identifies a field inside a protobufs message.
 --
@@ -42,7 +44,7 @@ import           Test.QuickCheck ( Arbitrary(..), choose )
 -- left to other, higher-level libraries.
 newtype FieldNumber = FieldNumber
   { getFieldNumber :: Word64 }
-  deriving (Bounded, Data, Enum, Eq, Generic, Hashable, NFData, Num, Ord)
+  deriving (Bounded, Data, Enum, Eq, Generic, Hashable, Lift, NFData, Num, Ord)
 
 instance Show FieldNumber where
   show (FieldNumber n) = show n
@@ -62,4 +64,4 @@ data WireType
   | Fixed32
   | Fixed64
   | LengthDelimited
-  deriving (Bounded, Data, Enum, Eq, Generic, Ord, Show)
+  deriving (Bounded, Data, Enum, Eq, Generic, Lift, Ord, Show)


### PR DESCRIPTION
This PR adds derived `Lift` instances for the `proto3-wire` types `FieldNumber` and `WireType`. These `Lift` instances are currently needed by [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt). Upstreaming these instances to `proto3-wire` will allow us to remove orphan `-XStandaloneDeriving` clauses that are currently in [`grpc-mqtt`](https://github.com/awakesecurity/grpc-mqtt).