### PR TITLE
Update `author`, `maintainer`, and `copyright` fields in cabal.

### DIFF
--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -5,9 +5,9 @@ version:      1.4.1
 synopsis:     A low-level implementation of the Protocol Buffers (version 3) wire format
 license:      Apache-2.0
 license-file: LICENSE
-author:       Awake Networks
-maintainer:   opensource@awakenetworks.com
-copyright:    2016 Awake Networks
+author:       Arista Networks <opensource@awakesecurity.com>
+maintainer:   Arista Networks <opensource@awakesecurity.com>
+copyright:    2017 Awake Security, 2021 Arista Networks
 category:     Codec
 build-type:   Simple
 


### PR DESCRIPTION
@rkaippully pointed out that we haven't yet updated the `author`/`maintainer` and `copyright` fields in the cabal file for `proto3-wire` yet in #96. This PR updates those fields to reflect our other repositories. 