### PR TITLE
Upgrade CI to `install-nix-action@v22`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3.5.3
         name: Checkout
 
-      - uses: cachix/install-nix-action@v21
+      - uses: cachix/install-nix-action@v22
         name: Install Nix
 
       - uses: cachix/cachix-action@v12


### PR DESCRIPTION
This PR upgrades to `install-nix-action@v22` in CI. This fixes an environment issue that occurs during the "install Nix` step, see: https://github.com/cachix/install-nix-action/issues/183.  