### PR TITLE
Bump upper bounds

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,1 +1,3 @@
 packages: .
+benchmarks: True
+tests: True

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -35,7 +35,7 @@ library
 
   build-depends:
       base >=4.12 && <=5.0
-    , bytestring >=0.10.6.0 && <0.12.0
+    , bytestring >=0.10.6.0 && <0.13.0
     , cereal >= 0.5.1 && <0.6
     , containers >=0.5 && < 0.7
     , deepseq >=1.4 && <1.6
@@ -44,9 +44,9 @@ library
     , primitive >=0.6.4 && <0.9
     , safe ==0.3.*
     , template-haskell >= 2.15.0 && < 2.22
-    , text >= 0.2 && <2.1
+    , text >= 0.2 && <2.2
     , text-short ==0.1.*
-    , transformers >=0.5.6.2 && <0.6
+    , transformers >=0.5.6.2 && <0.7
     , unordered-containers >= 0.1.0.0 && <0.3
     , vector >=0.12.0.2 && <0.14
     , QuickCheck >=2.8 && <3.0
@@ -75,17 +75,17 @@ test-suite tests
 
   build-depends:
       base >=4.9 && <=5.0
-    , bytestring >=0.10.6.0 && <0.12.0
+    , bytestring >=0.10.6.0 && <0.13.0
     , cereal >= 0.5.1 && <0.6
-    , doctest >= 0.7.0 && <0.21.0
+    , doctest >= 0.7.0 && <0.23.0
     , proto3-wire
     , QuickCheck >=2.8 && <3.0
-    , tasty >= 0.11 && <1.5
+    , tasty >= 0.11 && <1.6
     , tasty-hunit >= 0.9 && <0.11
     , tasty-quickcheck >= 0.8.4 && <0.11
-    , text >= 0.2 && <2.1
+    , text >= 0.2 && <2.2
     , text-short ==0.1.*
-    , transformers >=0.5.6.2 && <0.6
+    , transformers >=0.5.6.2 && <0.7
     , vector >=0.12.0.2 && <0.14
 
 benchmark bench


### PR DESCRIPTION
9.8 comes with `bytestring 0.12.1.0` so I was getting build failures when building out of nixpkgs. 
Not sure how #102 avoids that issue

I see CI only building up to 9.4, should that be updated?