### PR TITLE
Bump version to `proto3-wire-1.5.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+1.5.1
+  - Support GHC 9.14
+  - Support doctest 0.25
+
 1.5.0
   - As a breaking change, modify `Repeated` and `ToRepeated` to use `foldMap`-style
     folds and thereby avoid allocation of `BuildR` functions on the heap.  Use

--- a/proto3-wire.cabal
+++ b/proto3-wire.cabal
@@ -1,7 +1,7 @@
 cabal-version: >=1.10
 
 name:         proto3-wire
-version:      1.5.0
+version:      1.5.1
 synopsis:     A low-level implementation of the Protocol Buffers (version 3) wire format
 license:      Apache-2.0
 license-file: LICENSE


### PR DESCRIPTION
Bumping the patch version before releasing a new tarball as requested in https://github.com/awakesecurity/proto3-wire/pull/117 by @alexfmpe 